### PR TITLE
追加: PR作成時のGitHub Actions CI導入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
       - development
       - main
 
+# PHPUnitのFeatureテストはInertiaのBladeビュー(@vite)経由でpublic/build/manifest.jsonを参照し、
+# フロントエンドのtsc/buildはvendor/tightenco/ziggy(Ziggyのroute型定義)を参照するため、
+# バックエンド・フロントエンドを1ジョブにまとめ、実際のデプロイ手順と同じ順序
+# (composer install → npm run build → php artisan test)で実行する。
 jobs:
-  backend-tests:
-    name: Backend Tests (PHPUnit)
+  test:
+    name: Test (PHPUnit / tsc / lint / build)
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -61,48 +65,6 @@ jobs:
       - name: Install composer dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
 
-      - name: Run database migrations
-        run: php artisan migrate --force
-
-      - name: Run PHPUnit tests
-        run: php artisan test
-
-  frontend-checks:
-    name: Frontend Checks (tsc / lint / build)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: htdocs
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # tsc/build は vendor/tightenco/ziggy (Ziggyのroute型定義) を参照するため、
-      # composerでvendorを生成してから実行する必要がある
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-          extensions: mbstring, dom, fileinfo, filter, ctype, xml, session, curl, bcmath, intl, pdo, pdo_mysql, gd, redis, zip
-          coverage: none
-          tools: composer:v2
-
-      - name: Get composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache composer dependencies
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('htdocs/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Install composer dependencies
-        run: composer install --no-interaction --prefer-dist --optimize-autoloader
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -113,11 +75,14 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
-      - name: Type check
-        run: npm run tsc
-
       - name: Lint
         run: npm run lint
 
-      - name: Build
+      - name: Build (includes tsc type check)
         run: npm run build
+
+      - name: Run database migrations
+        run: php artisan migrate --force
+
+      - name: Run PHPUnit tests
+        run: php artisan test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,31 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # tsc/build は vendor/tightenco/ziggy (Ziggyのroute型定義) を参照するため、
+      # composerでvendorを生成してから実行する必要がある
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, dom, fileinfo, filter, ctype, xml, session, curl, bcmath, intl, pdo, pdo_mysql, gd, redis, zip
+          coverage: none
+          tools: composer:v2
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('htdocs/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,98 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - development
+      - main
+
+jobs:
+  backend-tests:
+    name: Backend Tests (PHPUnit)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: htdocs
+    env:
+      APP_ENV: testing
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+
+    services:
+      mysql:
+        image: mysql:8.0.43
+        env:
+          MYSQL_DATABASE: uchistock-db-testing
+          MYSQL_USER: db-user
+          MYSQL_PASSWORD: password
+          MYSQL_ROOT_PASSWORD: password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, dom, fileinfo, filter, ctype, xml, session, curl, bcmath, intl, pdo, pdo_mysql, gd, redis, zip
+          coverage: none
+          tools: composer:v2
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('htdocs/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install composer dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+      - name: Run database migrations
+        run: php artisan migrate --force
+
+      - name: Run PHPUnit tests
+        run: php artisan test
+
+  frontend-checks:
+    name: Frontend Checks (tsc / lint / build)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: htdocs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: htdocs/package-lock.json
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run tsc
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # UchiStock - 家庭在庫管理アプリ
 
+[![CI](https://github.com/north238/uchi_stock/actions/workflows/ci.yml/badge.svg)](https://github.com/north238/uchi_stock/actions/workflows/ci.yml)
+
 ## 概要
 
 UchiStockは、家庭の在庫管理を効率化するためのWebアプリケーションです。
@@ -180,6 +182,8 @@ open http://localhost:8080
 php artisan test
 
 ```
+
+`development` / `main` へのPR作成時は、GitHub Actions（`.github/workflows/ci.yml`）でPHPUnitテストとフロントエンドの型チェック・Lint・ビルド確認が自動実行されます。
 
 ## JSファイル（記述チェック・フォーマット）
 

--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -21,7 +21,6 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",
-        "laravel-lang/lang": "^12.17",
         "laravel/breeze": "^1.29",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.18",

--- a/htdocs/composer.lock
+++ b/htdocs/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf36973b65d4d42492f40842d0ff4017",
+    "content-hash": "37ded63b181d10447d6715107b2cf4c3",
     "packages": [
         {
             "name": "brick/math",
@@ -6578,81 +6578,6 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
             },
             "time": "2020-07-09T08:09:16+00:00"
-        },
-        {
-            "name": "laravel-lang/lang",
-            "version": "12.17.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Laravel-Lang/lang.git",
-                "reference": "b07184103fb64131d514667b8fd1d74c71105409"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/lang/zipball/b07184103fb64131d514667b8fd1d74c71105409",
-                "reference": "b07184103fb64131d514667b8fd1d74c71105409",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*"
-            },
-            "conflict": {
-                "laravel-lang/publisher": "<14.0"
-            },
-            "require-dev": {
-                "laravel-lang/publisher": "^14.0",
-                "laravel-lang/status-generator": "^1.13",
-                "php": "^8.1",
-                "phpunit/phpunit": "^9.6",
-                "symfony/var-dumper": "^5.0 || ^6.0"
-            },
-            "suggest": {
-                "arcanedev/laravel-lang": "Translations manager and checker for Laravel",
-                "laravel-lang/attributes": "Translations for field names of the forms",
-                "laravel-lang/http-statuses": "Translations for HTTP statuses",
-                "laravel-lang/publisher": "Easy installation and update of translation files for your project"
-            },
-            "type": "library",
-            "extra": {
-                "laravel": {
-                    "providers": [
-                        "LaravelLang\\Lang\\ServiceProvider"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "LaravelLang\\Lang\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Laravel-Lang Team",
-                    "homepage": "https://github.com/Laravel-Lang"
-                }
-            ],
-            "description": "Languages for Laravel",
-            "keywords": [
-                "lang",
-                "languages",
-                "laravel",
-                "lpm"
-            ],
-            "support": {
-                "issues": "https://github.com/Laravel-Lang/lang/issues",
-                "source": "https://github.com/Laravel-Lang/lang"
-            },
-            "funding": [
-                {
-                    "url": "https://opencollective.com/laravel-lang",
-                    "type": "open_collective"
-                }
-            ],
-            "time": "2023-02-19T13:40:37+00:00"
         },
         {
             "name": "laravel/breeze",

--- a/htdocs/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
+++ b/htdocs/resources/js/Pages/Profile/Partials/UpdateProfileInformationForm.tsx
@@ -3,7 +3,6 @@ import InputLabel from "@/Components/InputLabel";
 import PrimaryButton from "@/Components/PrimaryButton";
 import TextInput from "@/Components/TextInput";
 import { Link, useForm, usePage } from "@inertiajs/react";
-import { Transition } from "@headlessui/react";
 import { FormEventHandler } from "react";
 import { PageProps } from "@/types";
 


### PR DESCRIPTION
## Summary
- development・main向けPR作成時に、既存のバックエンドテスト（PHPUnit）とフロントエンド検証（lint/tsc/vite build）をGitHub Actionsで自動実行する `.github/workflows/ci.yml` を追加
- MySQLサービスコンテナは `docker/mysql/Dockerfile` と同じ `mysql:8.0.43` を使用し、`htdocs/.env.testing` の設定をそのまま活かす構成（DB_HOSTのみサービスコンテナ向けに上書き）
- InertiaのBladeビュー（`@vite`）が`public/build/manifest.json`を、フロントエンドの`tsc`/`build`が`vendor/tightenco/ziggy`（Ziggyのroute型定義）を、それぞれ相互に参照するため、バックエンド・フロントエンドを1ジョブに統合し `composer install → npm run build → php artisan test` の順で実行
- READMEにCIバッジと自動実行の説明を追記

## CI導入中に判明し、あわせて対応した既存の問題
- **セキュリティ**: `composer install` がComposerのマルウェア検知機能により停止。原因は`laravel-lang/lang 12.17.1`が[2026年5月のLaravel-Lang供給チェーン攻撃](https://www.aikido.dev/blog/supply-chain-attack-targets-laravel-lang-packages-with-credential-stealer)でPackagistのマルウェアリストに登録されたため。本プロジェクトの`composer.lock`は攻撃発生（2026年5月）より前の2025年4月に固定コミットを記録しており汚染の可能性は低いと判断したが、今後のクリーンインストールが恒久的に失敗するため、コード内で未使用（`Lang::`はLaravel本体のファサードで無関係）だったこのdev依存を削除した
- 既存のESLintエラー（`UpdateProfileInformationForm.tsx` の未使用import）を修正

## Test plan
- [x] ローカルのDocker環境（PHP 8.2 / MySQL 8.0.43、Linux）でワークフローと同一のコマンド列を実行し、52件全テスト・tsc・lint・buildが成功することを確認
- [x] `RefreshDatabase` がテスト用DB（uchistock-db-testing）のみに作用し、開発用DBに影響しないことを確認
- [x] 本PR上でGitHub Actionsが実際に成功することを確認（[実行ログ](https://github.com/north238/uchi_stock/actions/runs/30855811963)）

🤖 Generated with [Claude Code](https://claude.com/claude-code)